### PR TITLE
Fix Event Templates

### DIFF
--- a/tools/sfg/templates/frameworks/FrameworkTest.cpp.tpl
+++ b/tools/sfg/templates/frameworks/FrameworkTest.cpp.tpl
@@ -15,5 +15,5 @@ Framework${__NX_BASE_SYSTEM__}::~Framework${__NX_BASE_SYSTEM__}()
 
 void Framework${__NX_BASE_SYSTEM__}::Trigger${__NX_BASE_SYSTEM__}Event()
 {
-	this->_engine->emit("${__NX_BASE_SYSTEM__}EventKey", "${__NX_BASE_SYSTEM__}EventValue");
+	this->_engine->emit("${__NX_BASE_SYSTEM__}EventKey", {'4', '2'});
 }

--- a/tools/sfg/templates/system/TestSystem.cpp.tpl
+++ b/tools/sfg/templates/system/TestSystem.cpp.tpl
@@ -56,5 +56,5 @@ void nx::${__NX_BASE_SYSTEM__}System::event_${__NX_BASE_SYSTEM__}EventKey(const 
 	// As well as the public functions of the engine.
 	engine.ping();
 	// Finally we obviously also have access to the name and the data of the Event
-	nx::Log::inform(e.data);
+	nx::Log::inform(e.data.data());
 }


### PR DESCRIPTION
Use std::vector<char> instead of std::string for events